### PR TITLE
Stopped signatures from obscuring summaries

### DIFF
--- a/plugin/fugitive-blame-ext.vim
+++ b/plugin/fugitive-blame-ext.vim
@@ -3,7 +3,7 @@ function! s:log_message(commit)
 		return '(Not Committed Yet)'
 	endif
 	if !has_key(s:log_messages, a:commit)
-		let cmd_output = system('git --git-dir='.b:git_dir.' show --oneline '.a:commit)
+		let cmd_output = system('git --git-dir='.b:git_dir.' show --no-show-signature --oneline '.a:commit)
 		let first_line = split(cmd_output, '\n')[0]
 		let s:log_messages[a:commit] = substitute(first_line, '[a-z0-9]\+ ', '', '')
 	endif


### PR DESCRIPTION
If `.gitconfig` contains `showSignature = true`, the signature check gets prepended to the output. It then gets confused for the message, and the summary becomes something like "gpg: Signature made <date>". Adding `--no-show-signature` overrides that setting to restore the expected output format of `git show`, letting the plugin display the actual commit summary as intended.